### PR TITLE
docs: comprehensive README and architecture cleanup for v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,27 @@
 
 <h1 align="center">VocaMac</h1>
 
-[![Build & Test](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml/badge.svg)](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml) [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0) [![Platform: macOS](https://img.shields.io/badge/Platform-macOS%2013%2B-lightgrey.svg)](https://github.com/jatinkrmalik/vocamac) [![Swift 5.9+](https://img.shields.io/badge/Swift-5.9%2B-orange.svg)](https://swift.org) [![Website](https://img.shields.io/badge/Web-vocamac.com-007AFF.svg)](https://vocamac.com) [![GitHub stars](https://img.shields.io/github/stars/jatinkrmalik/vocamac?style=social)](https://github.com/jatinkrmalik/vocamac/stargazers)
+[![Build & Test](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml/badge.svg)](https://github.com/jatinkrmalik/vocamac/actions/workflows/ci.yml) [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0) [![Platform: macOS](https://img.shields.io/badge/Platform-macOS%2013%2B-lightgrey.svg)](https://github.com/jatinkrmalik/vocamac) [![Swift 5.9+](https://img.shields.io/badge/Swift-5.9%2B-orange.svg)](https://swift.org)
 
 
-**Local voice-to-text for macOS — powered by [WhisperKit](https://github.com/argmaxinc/WhisperKit)**
+**Local voice-to-text for macOS - powered by [WhisperKit](https://github.com/argmaxinc/WhisperKit)**
 
 VocaMac is a native macOS menu bar application that transcribes your voice to text locally on your machine. No cloud, no subscriptions, no data leaves your device. Just hold a hotkey, speak, and your words appear wherever your cursor is.
 
-🌐 [vocamac.com](https://vocamac.com) · 🐧 [VocaLinux](https://github.com/jatinkrmalik/vocalinux) · 🪟 VocaWin *(coming soon)*
+ [VocaLinux](https://github.com/jatinkrmalik/vocalinux) ·  **VocaMac** · 🪟 VocaWin *(coming soon)* · 🌐 [vocamac.com](https://vocamac.com)
 
 ---
 
 ## ✨ Features
 
-- **🔒 100% Local** — All audio processing happens on your machine. No internet required (except for one-time model downloads).
-- **⌨️ System-Wide Text Injection** — Transcribed text is typed wherever your cursor is: browsers, Slack, VS Code, spreadsheets, terminals — everywhere.
-- **🎯 Push-to-Talk** — Hold a hotkey (default: Right Option) to record. Release to transcribe.
-- **👆 Double-Tap Toggle** — Double-tap the hotkey to start/stop recording.
-- **🧠 Smart Model Selection** — Auto-detects your hardware (Apple Silicon/Intel, RAM) and recommends the best whisper model via WhisperKit.
-- **⚡ Native Apple Acceleration** — CoreML + Metal + Neural Engine acceleration on Apple Silicon. No manual setup.
-- **📊 Visual Feedback** — Menu bar icon changes color during recording and processing. Audio level indicator shows input.
-- **⚙️ Configurable** — Choose hotkeys, models, languages, silence detection thresholds, and more.
+- **🔒 100% Local** - All audio processing happens on your machine. No internet required (except for one-time model downloads).
+- **⌨️ System-Wide Text Injection** - Transcribed text is typed wherever your cursor is: browsers, Slack, VS Code, spreadsheets, terminals - everywhere.
+- **🎯 Push-to-Talk** - Hold a hotkey (default: Right Option) to record. Release to transcribe.
+- **👆 Double-Tap Toggle** - Double-tap the hotkey to start/stop recording.
+- **🧠 Smart Model Selection** - Auto-detects your hardware (Apple Silicon/Intel, RAM) and recommends the best whisper model via WhisperKit.
+- **⚡ Native Apple Acceleration** - CoreML + Metal + Neural Engine acceleration on Apple Silicon. No manual setup.
+- **📊 Visual Feedback** - Menu bar icon changes color during recording and processing. Audio level indicator shows input.
+- **⚙️ Configurable** - Choose hotkeys, models, languages, silence detection thresholds, and more.
 
 ---
 
@@ -50,8 +50,8 @@ Same accuracy, dramatically better Apple platform integration.
 
 - **macOS 13 (Ventura)** or later
 - **Xcode 15+** or Swift 5.9+ (for building)
-- **Microphone permission** — For audio capture
-- **Accessibility permission** — For global hotkeys and text injection
+- **Microphone permission** - For audio capture
+- **Accessibility permission** - For global hotkeys and text injection
 
 ---
 
@@ -64,7 +64,7 @@ Same accuracy, dramatically better Apple platform integration.
 git clone https://github.com/jatinkrmalik/vocamac.git
 cd vocamac
 
-# Build (first build downloads WhisperKit dependency — ~1 min)
+# Build (first build downloads WhisperKit dependency - ~1 min)
 swift build -c release
 
 # Run VocaMac
@@ -75,9 +75,9 @@ swift run -c release VocaMac
 
 1. **VocaMac appears in your menu bar** (microphone icon, no Dock icon)
 2. **Grant Microphone permission** when prompted
-3. **Grant Accessibility permission** — VocaMac will guide you to System Settings → Privacy & Security → Accessibility
-4. **First model download** — WhisperKit automatically downloads the recommended model for your device (~40-500MB depending on hardware)
-5. **Start dictating** — Hold the **Right Option** key, speak, and release. Your words appear at the cursor!
+3. **Grant Accessibility permission** - VocaMac will guide you to System Settings → Privacy & Security → Accessibility
+4. **First model download** - WhisperKit automatically downloads the recommended model for your device (~40-500MB depending on hardware)
+5. **Start dictating** - Hold the **Right Option** key, speak, and release. Your words appear at the cursor!
 
 ---
 
@@ -124,15 +124,16 @@ Models are downloaded automatically from [HuggingFace](https://huggingface.co/ar
 Open Settings from the menu bar popover or with **⌘,**
 
 ### General
-- **Activation mode** — Push-to-Talk or Double-Tap Toggle
-- **Hotkey** — Choose from Right Option, Right Command, Fn, function keys, etc.
-- **Language** — Auto-detect or specify (English, Spanish, French, German, Chinese, Japanese, and more)
+- **Activation mode** - Push-to-Talk or Double-Tap Toggle
+- **Hotkey** - Choose from Right Option, Right Command, Fn, function keys, etc.
+- **Language** - Auto-detect or specify (English, Spanish, French, German, Chinese, Japanese, and more)
 - **Launch at login**
 
 ### Audio
-- **Max recording duration** — 30s, 60s, 120s, or 300s
-- **Silence detection** — Auto-stop recording after configurable silence
-- **Input device** — Select which microphone to use
+- **Max recording duration** - 30s, 60s, 120s, or 300s
+- **Silence detection** - Auto-stop recording after configurable silence
+- **Sound effects** - Toggle audio feedback for recording start/stop
+- **Input device** - Select which microphone to use
 
 ### Models
 - View system info and WhisperKit's hardware recommendation
@@ -147,21 +148,21 @@ VocaMac is built with a clean, modular architecture using native Swift and Swift
 
 ```
 VocaMacApp (SwiftUI MenuBarExtra)
-├── AppState          — Central observable state
-├── HotKeyManager     — CGEventTap global hotkey listener
-├── AudioEngine       — AVAudioEngine mic capture (16kHz, mono, Float32)
-├── WhisperService    — WhisperKit async transcription wrapper
-│   └── ModelManager  — Model download, storage, device recommendations
-│       └── SystemInfo — Hardware detection & model recommendation
-├── TextInjector      — Clipboard + Cmd+V text injection
-├── MenuBarView       — Status popover UI
-└── SettingsView      — Configuration tabs (General, Models, Audio, About)
+├── AppState          - Central observable state
+├── HotKeyManager     - CGEventTap global hotkey listener
+├── AudioEngine       - AVAudioEngine mic capture (16kHz, mono, Float32)
+├── WhisperService    - WhisperKit async transcription wrapper
+│   └── ModelManager  - Model download, storage, device recommendations
+│       └── SystemInfo - Hardware detection & model recommendation
+├── SoundManager      - Audio feedback (start/stop recording cues)
+├── TextInjector      - Clipboard + Cmd+V text injection
+├── MenuBarView       - Status popover UI
+└── SettingsView      - Configuration tabs (General, Models, Audio, About)
 ```
 
 For detailed documentation, see:
-- [`docs/PRD.md`](docs/PRD.md) — Product Requirements Document
-- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — Technical Architecture
-- [`docs/DATA_MODEL.md`](docs/DATA_MODEL.md) — Data Model & Entity Relationships
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) - Technical Architecture
+- [`docs/DATA_MODEL.md`](docs/DATA_MODEL.md) - Data Model & Entity Relationships
 
 ---
 
@@ -189,6 +190,7 @@ VocaMac/
 │       │   ├── HotKeyManager.swift # CGEventTap global hotkeys
 │       │   ├── WhisperService.swift# WhisperKit transcription wrapper
 │       │   ├── ModelManager.swift  # Model download & management
+│       │   ├── SoundManager.swift  # Audio feedback for recording
 │       │   ├── TextInjector.swift  # Clipboard-based text injection
 │       │   └── SystemInfo.swift    # Hardware detection
 │       ├── Models/
@@ -198,10 +200,14 @@ VocaMac/
 │       └── Resources/
 ├── Tests/
 │   └── VocaMacTests/
+├── scripts/
+│   ├── build.sh                    # Build .app bundle
+│   ├── install.sh                  # Install to ~/.local/bin
+│   └── uninstall.sh                # Full uninstall & cleanup
+├── web/                            # Marketing website (vocamac.com)
 ├── docs/
-│   ├── PRD.md                      # Product Requirements Document
 │   ├── ARCHITECTURE.md             # Technical Architecture
-│   └── DATA_MODEL.md               # Data Model & ERD
+│   └── DATA_MODEL.md               # Data Model & Entity Relationships
 ├── LICENSE                         # AGPL-3.0 License
 └── .gitignore
 ```
@@ -212,7 +218,7 @@ VocaMac/
 # Debug build
 swift build
 
-# Release build (optimized — recommended for actual use)
+# Release build (optimized)
 swift build -c release
 
 # Run
@@ -220,19 +226,30 @@ swift run VocaMac
 
 # Run tests (requires Xcode)
 swift test
+
+# Build .app bundle
+./scripts/build.sh
+
+# Install launcher scripts to ~/.local/bin
+./scripts/install.sh
+```
+
+### Uninstall
+
+To completely remove VocaMac and all its data (downloaded models, preferences, caches):
+
+```bash
+./scripts/uninstall.sh
+```
+
+Use `--keep-build` to preserve build artifacts:
+
+```bash
+./scripts/uninstall.sh --keep-build
 ```
 
 ---
 
-## 🗺️ Roadmap
-
-- [x] **v0.1.0** — MVP: Menu bar app, push-to-talk, double-tap toggle, WhisperKit integration, text injection, settings
-- [ ] **v0.2.0** — Onboarding flow, transcription history, audio feedback sounds
-- [ ] **v0.3.0** — Custom prompts, real-time streaming transcription, word-level timestamps
-- [ ] **v0.4.0** — Auto-updates via Sparkle, code signing, DMG distribution
-- [ ] **v1.0.0** — Homebrew Cask, polished UI, performance tuning
-
----
 
 ## 🌐 Cross-Platform
 
@@ -240,9 +257,9 @@ VocaMac is the macOS member of the Voca family:
 
 | Platform | Project | Status |
 |----------|---------|--------|
-| 🐧 Linux | [VocaLinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Available |
-| 🍎 macOS | **VocaMac** (this project) | 🚧 MVP |
-| 🪟 Windows | VocaWin ([vocawin.com](https://vocawin.com)) | 📋 Planned |
+|  Linux | [VocaLinux](https://github.com/jatinkrmalik/vocalinux) | ✅ Available |
+|  macOS | [VocaMac](https://github.com/jatinkrmalik/vocamac) | 🚧 Alpha |
+| 🪟 Windows | [VocaWin](https://vocawin.com) | 📋 Planned |
 
 Each platform uses native technologies for the best possible integration, while sharing the same UX patterns and Whisper model family.
 
@@ -250,18 +267,24 @@ Each platform uses native technologies for the best possible integration, while 
 
 ## 🤝 Related Projects
 
-- [WhisperKit](https://github.com/argmaxinc/WhisperKit) — Swift native on-device speech recognition
-- [VocaLinux](https://github.com/jatinkrmalik/vocalinux) — Voice-to-text for Linux
-- [OpenAI Whisper](https://github.com/openai/whisper) — Original Whisper model
+- [WhisperKit](https://github.com/argmaxinc/WhisperKit) - Swift native on-device speech recognition
+- [VocaLinux](https://github.com/jatinkrmalik/vocalinux) - Voice-to-text for Linux
+- [OpenAI Whisper](https://github.com/openai/whisper) - Original Whisper model
+
+---
+
+## ⚠️ Known Limitations
+
+- **Ad-hoc code signing** - Accessibility and Input Monitoring permissions reset on every rebuild. Re-grant them after each build.
+- **First launch requires internet** - WhisperKit downloads the speech recognition model on first run. All subsequent launches work fully offline.
+- **macOS only** - Requires macOS 13 (Ventura) or later.
 
 ---
 
 ## 📄 License
 
-AGPL-3.0 License — see [LICENSE](LICENSE) for details.
+AGPL-3.0 License - see [LICENSE](LICENSE) for details.
 
 ---
 
-## 👨‍💻 Author
-
-**Jatin Kumar Malik** · [GitHub](https://github.com/jatinkrmalik) · [vocamac.com](https://vocamac.com)
+Made with ❤️ for the macOS community!

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# VocaMac — Technical Architecture Document
+# VocaMac - Technical Architecture Document
 
 **Version:** 1.0
 **Date:** 2026-03-04
@@ -48,7 +48,7 @@ VocaMac is a native macOS menu bar application built with Swift and SwiftUI. It 
 │  ┌──────────────────────────────────────────────────────┐    │
 │  │                   SwiftUI Layer                       │    │
 │  │  ┌──────────────┐  ┌────────────┐  ┌──────────────┐ │    │
-│  │  │ MenuBarView  │  │SettingsView│  │SettingsView│ │    │
+│  │  │ MenuBarView  │  │SettingsView│                  │    │
 │  │  └──────────────┘  └────────────┘  └──────────────┘ │    │
 │  └──────────────────────────────────────────────────────┘    │
 └──────────────────────────────────────────────────────────────┘
@@ -68,7 +68,7 @@ VocaMac is a native macOS menu bar application built with Swift and SwiftUI. It 
 | STT Engine | WhisperKit | 0.9.4+ | CoreML-based on-device speech-to-text |
 | Acceleration | Metal | macOS 13+ | GPU-accelerated inference on Apple Silicon |
 | Build | Swift Package Manager | 5.9+ | Dependency management and build |
-| Min OS | macOS 13 Ventura | — | Minimum supported macOS version |
+| Min OS | macOS 13 Ventura | - | Minimum supported macOS version |
 
 ---
 
@@ -85,6 +85,7 @@ VocaMacApp (entry point)
     │     │     └── ModelManager
     │     │           └── SystemInfo
     │     └── TextInjector
+    │     └── SoundManager
     ├── MenuBarView
     ├── SettingsView
     └── SettingsView
@@ -92,7 +93,7 @@ VocaMacApp (entry point)
 
 ### 3.2 Module Specifications
 
-#### 3.2.1 `VocaMacApp` — Application Entry Point
+#### 3.2.1 `VocaMacApp` - Application Entry Point
 
 **Responsibility:** Bootstrap the app, configure as menu bar-only (no Dock icon), initialize all services.
 
@@ -112,7 +113,7 @@ App Launch
   → App is ready
 ```
 
-#### 3.2.2 `AppState` — Central State Management
+#### 3.2.2 `AppState` - Central State Management
 
 **Responsibility:** Single source of truth for all app state. Observable object that drives reactive UI updates.
 
@@ -143,7 +144,7 @@ HotKey Triggered (stop)
   → Set appStatus = .idle
 ```
 
-#### 3.2.3 `HotKeyManager` — Global Hotkey Listener
+#### 3.2.3 `HotKeyManager` - Global Hotkey Listener
 
 **Responsibility:** Listen for system-wide key events to trigger recording start/stop.
 
@@ -177,7 +178,7 @@ On keyUp:
 
 **Required Permission:** Accessibility (System Settings → Privacy & Security → Accessibility)
 
-#### 3.2.4 `AudioEngine` — Microphone Capture
+#### 3.2.4 `AudioEngine` - Microphone Capture
 
 **Responsibility:** Capture audio from the microphone in the format required by WhisperKit.
 
@@ -205,7 +206,7 @@ Microphone → AVAudioInputNode → Format Converter → Buffer Accumulator
 - Report to AppState on each buffer for UI visualization
 - Throttle updates to ~15 Hz to avoid excessive UI refreshes
 
-#### 3.2.5 `WhisperService` — Speech-to-Text Engine
+#### 3.2.5 `WhisperService` - Speech-to-Text Engine
 
 **Responsibility:** Load WhisperKit models and perform transcription.
 
@@ -244,7 +245,7 @@ audioData: [Float]
 - Compile flag: `WHISPER_METAL=1` or `CoreML_METAL=1`
 - Falls back to CPU on Intel Macs
 
-#### 3.2.6 `ModelManager` — Model Lifecycle Management
+#### 3.2.6 `ModelManager` - Model Lifecycle Management
 
 **Responsibility:** Discover, download, verify, and manage whisper model files.
 
@@ -277,7 +278,7 @@ audioData: [Float]
 4. Verify SHA256 checksum after download
 5. Move to models directory on success
 
-#### 3.2.7 `SystemInfo` — Hardware Detection
+#### 3.2.7 `SystemInfo` - Hardware Detection
 
 **Responsibility:** Detect system hardware capabilities and recommend optimal model size.
 
@@ -300,7 +301,7 @@ Intel:
   RAM ≥ 32 GB → small
 ```
 
-#### 3.2.8 `TextInjector` — System-Wide Text Insertion
+#### 3.2.8 `TextInjector` - System-Wide Text Insertion
 
 **Responsibility:** Insert transcribed text at the cursor position in any application.
 
@@ -406,8 +407,8 @@ Main Thread (Text Injection)
 ```
 
 **Key Threading Rules:**
-1. Audio capture callbacks run on AVAudioEngine's internal thread — keep work minimal
-2. Transcription runs via `Task { }` on a background executor — never block the main thread
+1. Audio capture callbacks run on AVAudioEngine's internal thread - keep work minimal
+2. Transcription runs via `Task { }` on a background executor - never block the main thread
 3. UI updates via `@MainActor` or `DispatchQueue.main`
 4. CGEvent posting should happen from the main thread
 5. Model loading/downloading uses async/await on background threads
@@ -427,7 +428,7 @@ let options = [kAXTrustedCheckOptionPrompt.takeRetainedValue(): true] as CFDicti
 let isTrusted = AXIsProcessTrustedWithOptions(options)
 ```
 
-Note: Unlike microphone access, Accessibility permission cannot be granted via a system dialog — the user must manually add the app in System Settings. The app should provide clear instructions.
+Note: Unlike microphone access, Accessibility permission cannot be granted via a system dialog - the user must manually add the app in System Settings. The app should provide clear instructions.
 
 ---
 
@@ -441,7 +442,7 @@ Package.swift
   ├── Products: VocaMac executable
   ├── Dependencies: WhisperKit (vendored or submodule)
   ├── Swift settings: -O (optimized for release)
-  └── C settings: -DCoreML_METAL=1 (Metal acceleration)
+  └── Platforms: .macOS(.v13)
 ```
 
 ### 7.2 Build Commands
@@ -457,14 +458,14 @@ swift build -c release
 swift run VocaMac
 
 # Create app bundle (requires additional scripting)
-./scripts/bundle.sh
+./scripts/build.sh
 ```
 
 ### 7.3 Distribution Strategy (MVP)
 
-1. **GitHub Releases** — DMG or ZIP containing the .app bundle
-2. **Homebrew Cask** — `brew install --cask vocamac` (post-MVP)
-3. **Mac App Store** — Future consideration (requires sandbox compliance)
+1. **GitHub Releases** - DMG or ZIP containing the .app bundle
+2. **Homebrew Cask** - `brew install --cask vocamac` (post-MVP)
+3. **Mac App Store** - Future consideration (requires sandbox compliance)
 
 ---
 
@@ -475,9 +476,9 @@ swift run VocaMac
 While VocaMac is a native macOS app, the architecture is designed to facilitate a future Windows port (VocaWin):
 
 ```
-Shared (C/C++):
-  └── WhisperKit           ← Already cross-platform
-  └── Model format (CoreML)   ← Already cross-platform
+Shared Concepts:
+  └── Whisper models        ← Same model family across platforms
+  └── UX patterns           ← Same user interaction design
 
 Platform-Specific:
   ┌──────────────────────┬──────────────────────┐
@@ -494,10 +495,10 @@ Platform-Specific:
 
 ### 8.2 What Can Be Shared
 
-- **WhisperKit** — The core engine is already cross-platform
-- **Model files** — CoreML model format works on all platforms
-- **Model catalog** — Same download URLs, checksums, metadata
-- **UX patterns** — Same user flows and interaction design
+- **Whisper models** - Same OpenAI Whisper model family on all platforms
+- **Model files** - Each platform uses its optimal format (CoreML on macOS, GGML on Linux/Windows)
+- **Model catalog** - Same model variants and metadata
+- **UX patterns** - Same user flows and interaction design
 
 ### 8.3 What Must Be Platform-Specific
 
@@ -519,7 +520,7 @@ Platform-Specific:
 | Model file corrupted/missing | Re-download model, fall back to bundled tiny |
 | Audio device disconnected | Detect and notify user, pause recording |
 | Transcription fails | Show error in menu bar popover, log details |
-| Clipboard restore fails | Log warning, don't crash — clipboard is transient |
+| Clipboard restore fails | Log warning, don't crash - clipboard is transient |
 | Out of memory during transcription | Suggest a smaller model, show clear error |
 | Network error during model download | Retry with exponential backoff, allow manual retry |
 
@@ -528,9 +529,9 @@ Platform-Specific:
 ## 10. Security Considerations
 
 1. **No network communication** except model downloads from Hugging Face
-2. **No telemetry or analytics** — fully offline operation
-3. **Audio data never leaves the device** — processed entirely in-memory
-4. **No persistent audio storage** — audio buffers are discarded after transcription
-5. **Model files verified by checksum** — prevent tampering
-6. **Code signing** — App should be signed with a Developer ID certificate
-7. **Hardened runtime** — Enable for Gatekeeper compatibility
+2. **No telemetry or analytics** - fully offline operation
+3. **Audio data never leaves the device** - processed entirely in-memory
+4. **No persistent audio storage** - audio buffers are discarded after transcription
+5. **Model files verified by checksum** - prevent tampering
+6. **Code signing** - App should be signed with a Developer ID certificate
+7. **Hardened runtime** - Enable for Gatekeeper compatibility


### PR DESCRIPTION
Final documentation cleanup before v0.1.0 alpha release.

### README Fixes
- Fixed truncated badge line
- Consistent platform naming (VocaLinux / VocaMac / VocaWin) with platform icons
- Fixed cross-platform table (proper links, no parenthesized URLs)
- Removed broken PRD.md link
- Added SoundManager.swift, scripts/, web/ to project structure
- Added Sound Effects to Configuration section
- Added build/install/uninstall script docs
- Added Known Limitations section
- Removed Roadmap section (tracked via GitHub Issues now)
- Replaced Author section with 'Made with ❤️ for the macOS community!'
- Removed all em-dashes

### ARCHITECTURE.md Fixes
- Fixed duplicate SettingsView in UI layer diagram
- Fixed bundle.sh -> build.sh reference
- Fixed incorrect cross-platform claims (WhisperKit and CoreML are Apple-only)
- Added SoundManager to module dependency graph
- Removed all em-dashes