### PR TITLE
chore: improve CI and add release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,40 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     name: Build & Test
     runs-on: macos-15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
+      - name: Build (Debug)
         run: swift build
 
       - name: Test
         run: swift test
+
+      - name: Build (Release)
+        run: swift build -c release
+
+      - name: Verify app bundle
+        run: |
+          ./scripts/build.sh release
+          test -d VocaMac.app || exit 1
+          codesign -v VocaMac.app
+          echo "App bundle verified"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    name: Build & Release
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Update version in build script
+        run: |
+          sed -i '' "s/CFBundleVersion.*/<key>CFBundleVersion<\/key>/" scripts/build.sh || true
+          echo "Building version: ${{ steps.version.outputs.VERSION }}"
+
+      - name: Build release app bundle
+        run: ./scripts/build.sh release
+
+      - name: Verify code signature
+        run: codesign -v --deep --strict VocaMac.app
+
+      - name: Run tests
+        run: swift test
+
+      - name: Create DMG
+        run: |
+          mkdir -p dmg-staging
+          cp -R VocaMac.app dmg-staging/
+          ln -s /Applications dmg-staging/Applications
+
+          hdiutil create -volname "VocaMac" \
+            -srcfolder dmg-staging \
+            -ov -format UDZO \
+            "VocaMac-${{ steps.version.outputs.VERSION }}-arm64.dmg"
+
+          echo "DMG created:"
+          ls -lh VocaMac-*.dmg
+
+      - name: Create ZIP archive
+        run: |
+          ditto -c -k --sequesterRsrc --keepParent VocaMac.app \
+            "VocaMac-${{ steps.version.outputs.VERSION }}-arm64.zip"
+
+          echo "ZIP created:"
+          ls -lh VocaMac-*.zip
+
+      - name: Generate checksums
+        run: |
+          shasum -a 256 VocaMac-*.dmg VocaMac-*.zip > checksums.txt
+          cat checksums.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          draft: true
+          files: |
+            VocaMac-*.dmg
+            VocaMac-*.zip
+            checksums.txt
+          body: |
+            ## VocaMac ${{ steps.version.outputs.VERSION }}
+
+            ### Installation
+
+            1. Download `VocaMac-${{ steps.version.outputs.VERSION }}-arm64.dmg`
+            2. Open the DMG and drag VocaMac to Applications
+            3. Open VocaMac from Applications
+            4. Grant Microphone, Accessibility, and Input Monitoring permissions when prompted
+
+            ### Checksums (SHA-256)
+            See `checksums.txt` for verification.
+
+            ### Requirements
+            - macOS 13 (Ventura) or later
+            - Apple Silicon (arm64)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,154 @@
+# VocaMac Release Process
+
+## Overview
+
+VocaMac uses GitHub Actions for CI/CD. Releases are triggered by pushing a version tag (e.g., `v0.1.0`). The release workflow builds the app, creates a DMG and ZIP archive, generates checksums, and publishes a draft GitHub Release.
+
+## Versioning
+
+We follow [Semantic Versioning](https://semver.org/):
+
+```
+vMAJOR.MINOR.PATCH
+```
+
+- **MAJOR** - Breaking changes or significant redesigns
+- **MINOR** - New features, backward compatible
+- **PATCH** - Bug fixes, minor improvements
+
+Pre-release versions use suffixes: `v0.1.0-alpha`, `v0.1.0-beta.1`
+
+## Release Checklist
+
+### Before Tagging
+
+1. **Ensure all PRs are merged** into `main`
+2. **Verify CI passes** on the latest `main` commit
+3. **Update version number** in `scripts/build.sh` (both `CFBundleVersion` and `CFBundleShortVersionString`)
+4. **Test locally**:
+   ```bash
+   ./scripts/build.sh release
+   open VocaMac.app
+   ```
+5. **Verify core functionality**:
+   - App appears in menu bar
+   - Push-to-talk recording works
+   - Transcription produces correct text
+   - Text injection works at cursor
+   - Settings dialog opens and all tabs function
+   - Model download and switching works
+   - Sound effects play on start/stop
+6. **Review README** for accuracy
+
+### Creating a Release
+
+1. **Tag the release**:
+   ```bash
+   git tag -a v0.1.0 -m "VocaMac v0.1.0 - Alpha Release"
+   git push origin v0.1.0
+   ```
+
+2. **GitHub Actions automatically**:
+   - Builds the release binary
+   - Creates `VocaMac.app` bundle with ad-hoc signing
+   - Packages as DMG (`VocaMac-0.1.0-arm64.dmg`)
+   - Packages as ZIP (`VocaMac-0.1.0-arm64.zip`)
+   - Generates SHA-256 checksums
+   - Creates a **draft** GitHub Release with all artifacts
+
+3. **Review the draft release** at https://github.com/jatinkrmalik/vocamac/releases
+   - Edit release notes if needed
+   - Verify artifacts are attached
+   - **Publish** the release when ready
+
+4. **Website auto-deploys** when the release is published (via `deploy-website.yml`)
+
+## Release Artifacts
+
+Each release produces:
+
+| Artifact | Description |
+|----------|-------------|
+| `VocaMac-X.Y.Z-arm64.dmg` | DMG disk image with drag-to-Applications installer |
+| `VocaMac-X.Y.Z-arm64.zip` | ZIP archive of VocaMac.app |
+| `checksums.txt` | SHA-256 checksums for verification |
+
+## Architecture Support
+
+Currently **Apple Silicon (arm64) only**. The build runs on `macos-15` runners which are arm64.
+
+For universal binary support (arm64 + x86_64) in the future:
+```bash
+swift build -c release --arch arm64 --arch x86_64
+```
+
+## Code Signing
+
+### Current (Alpha)
+
+- **Ad-hoc signing** (no Apple Developer certificate)
+- Users must manually grant permissions after each install
+- Gatekeeper will show "unidentified developer" warning
+- Users bypass with: Right-click > Open > Open
+
+### Future (GA Release)
+
+- Sign with Apple Developer ID certificate
+- Notarize with Apple for Gatekeeper clearance
+- No security warnings for end users
+- Permissions persist across updates
+
+See [Issue #27](https://github.com/jatinkrmalik/vocamac/issues/27) for tracking.
+
+## CI Workflows
+
+### `ci.yml` - Build & Test
+
+- **Triggers**: Push to `main`, pull requests to `main`
+- **Steps**: Debug build, test suite, release build, app bundle verification
+- **Caching**: SPM dependencies cached for faster builds
+- **Concurrency**: Cancels in-progress runs for the same branch
+
+### `release.yml` - Release
+
+- **Triggers**: Push of version tags (`v*`)
+- **Steps**: Build, test, create DMG + ZIP, generate checksums, create draft release
+- **Output**: Draft GitHub Release with downloadable artifacts
+
+### `deploy-website.yml` - Website
+
+- **Triggers**: Release published, manual dispatch
+- **Steps**: Deploy `web/` directory to GitHub Pages
+
+## Manual Release (Without CI)
+
+If you need to create a release locally:
+
+```bash
+# Build the app
+./scripts/build.sh release
+
+# Create DMG
+mkdir -p dmg-staging
+cp -R VocaMac.app dmg-staging/
+ln -s /Applications dmg-staging/Applications
+hdiutil create -volname "VocaMac" -srcfolder dmg-staging -ov -format UDZO "VocaMac-0.1.0-arm64.dmg"
+
+# Create ZIP
+ditto -c -k --sequesterRsrc --keepParent VocaMac.app "VocaMac-0.1.0-arm64.zip"
+
+# Generate checksums
+shasum -a 256 VocaMac-*.dmg VocaMac-*.zip > checksums.txt
+```
+
+Then upload the artifacts manually to the GitHub Release page.
+
+## Hotfix Process
+
+For critical bugs in a released version:
+
+1. Create a branch from the release tag: `git checkout -b fix/critical-bug v0.1.0`
+2. Fix the bug, commit, push
+3. Create a PR to `main`
+4. After merge, tag a patch release: `v0.1.1`
+5. Push the tag to trigger the release workflow


### PR DESCRIPTION
## Changes

### CI Improvements (`ci.yml`)
- **SPM dependency caching** - faster builds using `actions/cache@v4`
- **Concurrency control** - cancels in-progress runs for the same branch
- **30-minute timeout** - prevents hung builds
- **Release build check** - verifies release build succeeds (not just debug)
- **App bundle verification** - runs `build.sh`, verifies `.app` exists and codesign passes

### New Release Workflow (`release.yml`)
Triggered by pushing a version tag (`v*`):
1. Builds release binary and `.app` bundle
2. Runs test suite
3. Creates DMG with drag-to-Applications installer
4. Creates ZIP archive
5. Generates SHA-256 checksums
6. Publishes a **draft** GitHub Release with all artifacts

### New Release Documentation (`docs/RELEASE.md`)
- Complete release process with checklist
- Versioning conventions (semver)
- CI workflow descriptions
- Manual release instructions (without CI)
- Hotfix process
- Code signing roadmap (ad-hoc now, Developer ID later)

### How to Release
After merging this PR:
```bash
git tag -a v0.1.0 -m "VocaMac v0.1.0 - Alpha Release"
git push origin v0.1.0
```
Then review and publish the draft release on GitHub.