### PR TITLE
fix: wrap #Preview in #if DEBUG to fix CLI build without full Xcode

### DIFF
--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -854,7 +854,9 @@ extension View {
     }
 }
 
+#if DEBUG
 #Preview {
     OnboardingView()
         .environmentObject(AppState())
 }
+#endif


### PR DESCRIPTION
The #Preview macro relies on PreviewsMacros, which is part of the full Xcode.app IDE and is not available when building with Xcode Command Line Tools only. This causes a build error:

```
error: external macro implementation type 'PreviewsMacros.SwiftUIView' could not be found for macro 'Preview(_:body:)'
```

Wrapping the preview block in #if DEBUG ensures it is only compiled in environments where the preview infrastructure is available. This has no impact on the production app — #Preview blocks are never included in release builds.