### PR TITLE
fix: sync onboarding hotkey mode immediately

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -790,7 +790,9 @@ final class AppState: ObservableObject {
     }
     func completeOnboarding() {
         syncHotKeyConfiguration()
-        hotKeyManager.resetKeyState()
+        if !isRecording {
+            hotKeyManager.resetKeyState()
+        }
         hasCompletedOnboarding = true
         VocaLogger.info(.appState, "Onboarding completed")
     }

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -399,6 +399,21 @@ final class AppState: ObservableObject {
     func requestAccessibilityPermission() { permissionManager.requestAccessibilityPermission() }
     func requestInputMonitoringPermission() { permissionManager.requestInputMonitoringPermission() }
 
+    // MARK: - Hotkey Configuration
+
+    /// Apply persisted hotkey settings to the active listener.
+    /// `@AppStorage` updates save preferences immediately, but an already-running
+    /// event tap also needs its in-memory configuration refreshed.
+    func syncHotKeyConfiguration() {
+        hotKeyManager.updateConfiguration(
+            keyCode: hotKeyCode,
+            mode: activationMode,
+            doubleTapThreshold: doubleTapThreshold,
+            safetyTimeout: Double(maxRecordingDuration) + 5.0
+        )
+        VocaLogger.info(.appState, "Hotkey configuration synced (keyCode=\(hotKeyCode), mode=\(activationMode.rawValue))")
+    }
+
     // MARK: - Force Recovery
 
     /// Forcibly reset the entire recording pipeline to idle state.
@@ -770,6 +785,7 @@ final class AppState: ObservableObject {
         VocaLogger.info(.appState, "Startup complete!")
     }
     func completeOnboarding() {
+        syncHotKeyConfiguration()
         hasCompletedOnboarding = true
         VocaLogger.info(.appState, "Onboarding completed")
     }

--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -108,6 +108,10 @@ final class AppState: ObservableObject {
     @AppStorage("vocamac.translationEnabled") var translationEnabled: Bool = false
     @AppStorage("vocamac.logLevel") var logLevel: String = "info"
 
+    private var hotKeySafetyTimeout: Double {
+        Double(maxRecordingDuration) + 5.0
+    }
+
     // MARK: - Services
 
     let audioEngine: AudioRecording
@@ -374,7 +378,7 @@ final class AppState: ObservableObject {
                 keyCode: self.hotKeyCode,
                 mode: self.activationMode,
                 doubleTapThreshold: self.doubleTapThreshold,
-                safetyTimeout: Double(self.maxRecordingDuration) + 5.0
+                safetyTimeout: self.hotKeySafetyTimeout
             )
             VocaLogger.info(.appState, "Hotkey listener started after permission grant")
         }
@@ -409,9 +413,9 @@ final class AppState: ObservableObject {
             keyCode: hotKeyCode,
             mode: activationMode,
             doubleTapThreshold: doubleTapThreshold,
-            safetyTimeout: Double(maxRecordingDuration) + 5.0
+            safetyTimeout: hotKeySafetyTimeout
         )
-        VocaLogger.info(.appState, "Hotkey configuration synced (keyCode=\(hotKeyCode), mode=\(activationMode.rawValue))")
+        VocaLogger.debug(.appState, "Hotkey configuration synced (keyCode=\(hotKeyCode), mode=\(activationMode.rawValue))")
     }
 
     // MARK: - Force Recovery
@@ -772,7 +776,7 @@ final class AppState: ObservableObject {
             keyCode: hotKeyCode,
             mode: activationMode,
             doubleTapThreshold: doubleTapThreshold,
-            safetyTimeout: Double(maxRecordingDuration) + 5.0
+            safetyTimeout: hotKeySafetyTimeout
         )
         if hotKeyManager.isListening {
             VocaLogger.info(.appState, "Hotkey listener active (keyCode=\(hotKeyCode), mode=\(activationMode.rawValue))")
@@ -786,6 +790,7 @@ final class AppState: ObservableObject {
     }
     func completeOnboarding() {
         syncHotKeyConfiguration()
+        hotKeyManager.resetKeyState()
         hasCompletedOnboarding = true
         VocaLogger.info(.appState, "Onboarding completed")
     }

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -665,7 +665,12 @@ struct HotkeyConfigStep: View {
                             Slider(
                                 value: $appState.doubleTapThreshold,
                                 in: 0.2...0.8,
-                                step: 0.05
+                                step: 0.05,
+                                onEditingChanged: { isEditing in
+                                    if !isEditing {
+                                        appState.syncHotKeyConfiguration()
+                                    }
+                                }
                             )
                             Text("\(String(format: "%.2f", appState.doubleTapThreshold))s")
                                 .monospacedDigit()
@@ -685,13 +690,12 @@ struct HotkeyConfigStep: View {
             Spacer()
         }
         .padding()
+        // Keep the live listener aligned with wizard fields.
+        // Completion syncs the full persisted config.
         .onChange(of: appState.activationMode) { _ in
             appState.syncHotKeyConfiguration()
         }
         .onChange(of: appState.hotKeyCode) { _ in
-            appState.syncHotKeyConfiguration()
-        }
-        .onChange(of: appState.doubleTapThreshold) { _ in
             appState.syncHotKeyConfiguration()
         }
     }

--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -685,6 +685,15 @@ struct HotkeyConfigStep: View {
             Spacer()
         }
         .padding()
+        .onChange(of: appState.activationMode) { _ in
+            appState.syncHotKeyConfiguration()
+        }
+        .onChange(of: appState.hotKeyCode) { _ in
+            appState.syncHotKeyConfiguration()
+        }
+        .onChange(of: appState.doubleTapThreshold) { _ in
+            appState.syncHotKeyConfiguration()
+        }
     }
 }
 

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -86,14 +86,16 @@ struct GeneralSettingsTab: View {
                         Slider(
                             value: $appState.doubleTapThreshold,
                             in: 0.2...0.8,
-                            step: 0.05
+                            step: 0.05,
+                            onEditingChanged: { isEditing in
+                                if !isEditing {
+                                    appState.syncHotKeyConfiguration()
+                                }
+                            }
                         )
                         Text("\(String(format: "%.2f", appState.doubleTapThreshold))s")
                             .monospacedDigit()
                             .frame(width: 40)
-                    }
-                    .onChange(of: appState.doubleTapThreshold) { _ in
-                        appState.syncHotKeyConfiguration()
                     }
 
                     Text("Shorter = faster double-tap required. Longer = more forgiving.")

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -60,8 +60,8 @@ struct GeneralSettingsTab: View {
                     }
                 }
                 .pickerStyle(.radioGroup)
-                .onChange(of: appState.activationMode) { newMode in
-                    appState.hotKeyManager.updateConfiguration(mode: newMode)
+                .onChange(of: appState.activationMode) { _ in
+                    appState.syncHotKeyConfiguration()
                 }
 
                 Text(appState.activationMode.description)
@@ -76,8 +76,8 @@ struct GeneralSettingsTab: View {
                         Text(hotKey.name).tag(hotKey.keyCode)
                     }
                 }
-                .onChange(of: appState.hotKeyCode) { newCode in
-                    appState.hotKeyManager.updateConfiguration(keyCode: newCode)
+                .onChange(of: appState.hotKeyCode) { _ in
+                    appState.syncHotKeyConfiguration()
                 }
 
                 if appState.activationMode == .doubleTapToggle {
@@ -92,8 +92,8 @@ struct GeneralSettingsTab: View {
                             .monospacedDigit()
                             .frame(width: 40)
                     }
-                    .onChange(of: appState.doubleTapThreshold) { newVal in
-                        appState.hotKeyManager.updateConfiguration(doubleTapThreshold: newVal)
+                    .onChange(of: appState.doubleTapThreshold) { _ in
+                        appState.syncHotKeyConfiguration()
                     }
 
                     Text("Shorter = faster double-tap required. Longer = more forgiving.")
@@ -547,6 +547,9 @@ struct AudioSettingsTab: View {
                     Text("60 seconds").tag(60)
                     Text("120 seconds").tag(120)
                     Text("300 seconds (5 min)").tag(300)
+                }
+                .onChange(of: appState.maxRecordingDuration) { _ in
+                    appState.syncHotKeyConfiguration()
                 }
 
                 Text("Recording will automatically stop after this duration.")

--- a/Tests/VocaMacTests/AppStateTests.swift
+++ b/Tests/VocaMacTests/AppStateTests.swift
@@ -188,6 +188,7 @@ final class AppStateOnboardingTests: XCTestCase {
         XCTAssertEqual(mocks.hotKeyManager.lastKeyCode, 58)
         XCTAssertEqual(mocks.hotKeyManager.lastDoubleTapThreshold, 0.55)
         XCTAssertEqual(mocks.hotKeyManager.lastSafetyTimeout, 125.0)
+        XCTAssertEqual(mocks.hotKeyManager.resetKeyStateCallCount, 1)
     }
 
     @MainActor
@@ -205,6 +206,19 @@ final class AppStateOnboardingTests: XCTestCase {
         XCTAssertEqual(mocks.hotKeyManager.lastKeyCode, 54)
         XCTAssertEqual(mocks.hotKeyManager.lastDoubleTapThreshold, 0.3)
         XCTAssertEqual(mocks.hotKeyManager.lastSafetyTimeout, 35.0)
+    }
+
+    @MainActor
+    func testSyncHotKeyConfigurationAppliesDefaultSettings() {
+        let (appState, mocks) = AppState.makeTestState()
+
+        appState.syncHotKeyConfiguration()
+
+        XCTAssertEqual(mocks.hotKeyManager.updateConfigurationCallCount, 1)
+        XCTAssertEqual(mocks.hotKeyManager.lastMode, .pushToTalk)
+        XCTAssertEqual(mocks.hotKeyManager.lastKeyCode, 61)
+        XCTAssertEqual(mocks.hotKeyManager.lastDoubleTapThreshold, 0.4)
+        XCTAssertEqual(mocks.hotKeyManager.lastSafetyTimeout, 65.0)
     }
 
     @MainActor

--- a/Tests/VocaMacTests/AppStateTests.swift
+++ b/Tests/VocaMacTests/AppStateTests.swift
@@ -139,7 +139,22 @@ final class AppStateOnboardingTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        UserDefaults.standard.removeObject(forKey: "vocamac.hasCompletedOnboarding")
+        clearPersistedSettings()
+    }
+
+    override func tearDown() {
+        clearPersistedSettings()
+        super.tearDown()
+    }
+
+    private func clearPersistedSettings() {
+        [
+            "vocamac.hasCompletedOnboarding",
+            "vocamac.activationMode",
+            "vocamac.hotKeyCode",
+            "vocamac.doubleTapThreshold",
+            "vocamac.maxRecordingDuration",
+        ].forEach { UserDefaults.standard.removeObject(forKey: $0) }
     }
 
     @MainActor
@@ -156,6 +171,40 @@ final class AppStateOnboardingTests: XCTestCase {
         appState.completeOnboarding()
 
         XCTAssertTrue(appState.hasCompletedOnboarding)
+    }
+
+    @MainActor
+    func testCompleteOnboardingSyncsHotKeyConfiguration() {
+        let (appState, mocks) = AppState.makeTestState()
+        appState.activationMode = .doubleTapToggle
+        appState.hotKeyCode = 58
+        appState.doubleTapThreshold = 0.55
+        appState.maxRecordingDuration = 120
+
+        appState.completeOnboarding()
+
+        XCTAssertEqual(mocks.hotKeyManager.updateConfigurationCallCount, 1)
+        XCTAssertEqual(mocks.hotKeyManager.lastMode, .doubleTapToggle)
+        XCTAssertEqual(mocks.hotKeyManager.lastKeyCode, 58)
+        XCTAssertEqual(mocks.hotKeyManager.lastDoubleTapThreshold, 0.55)
+        XCTAssertEqual(mocks.hotKeyManager.lastSafetyTimeout, 125.0)
+    }
+
+    @MainActor
+    func testSyncHotKeyConfigurationAppliesCurrentSettings() {
+        let (appState, mocks) = AppState.makeTestState()
+        appState.activationMode = .doubleTapToggle
+        appState.hotKeyCode = 54
+        appState.doubleTapThreshold = 0.3
+        appState.maxRecordingDuration = 30
+
+        appState.syncHotKeyConfiguration()
+
+        XCTAssertEqual(mocks.hotKeyManager.updateConfigurationCallCount, 1)
+        XCTAssertEqual(mocks.hotKeyManager.lastMode, .doubleTapToggle)
+        XCTAssertEqual(mocks.hotKeyManager.lastKeyCode, 54)
+        XCTAssertEqual(mocks.hotKeyManager.lastDoubleTapThreshold, 0.3)
+        XCTAssertEqual(mocks.hotKeyManager.lastSafetyTimeout, 35.0)
     }
 
     @MainActor

--- a/Tests/VocaMacTests/AppStateTests.swift
+++ b/Tests/VocaMacTests/AppStateTests.swift
@@ -192,6 +192,18 @@ final class AppStateOnboardingTests: XCTestCase {
     }
 
     @MainActor
+    func testCompleteOnboardingDoesNotResetHotKeyStateWhileRecording() {
+        let (appState, mocks) = AppState.makeTestState()
+        appState.isRecording = true
+
+        appState.completeOnboarding()
+
+        XCTAssertEqual(mocks.hotKeyManager.updateConfigurationCallCount, 1)
+        XCTAssertEqual(mocks.hotKeyManager.resetKeyStateCallCount, 0)
+        XCTAssertTrue(appState.hasCompletedOnboarding)
+    }
+
+    @MainActor
     func testSyncHotKeyConfigurationAppliesCurrentSettings() {
         let (appState, mocks) = AppState.makeTestState()
         appState.activationMode = .doubleTapToggle

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -96,6 +96,7 @@ final class MockHotKeyManager: HotKeyMonitoring {
     var lastDoubleTapThreshold: Double?
     var lastSafetyTimeout: Double?
     var resetKeyStateCallCount = 0
+    var updateConfigurationCallCount = 0
 
     private var accessibilityPermission = false
 
@@ -125,6 +126,19 @@ final class MockHotKeyManager: HotKeyMonitoring {
     }
 
     func _updateConfiguration(keyCode: Int?, mode: ActivationMode?, doubleTapThreshold: Double?, safetyTimeout: Double?) {
+        updateConfigurationCallCount += 1
+        if let keyCode = keyCode {
+            lastKeyCode = keyCode
+        }
+        if let mode = mode {
+            lastMode = mode
+        }
+        if let doubleTapThreshold = doubleTapThreshold {
+            lastDoubleTapThreshold = doubleTapThreshold
+        }
+        if let safetyTimeout = safetyTimeout {
+            lastSafetyTimeout = safetyTimeout
+        }
     }
 }
 


### PR DESCRIPTION
The setup wizard saved activation mode changes through `@AppStorage`, but the global hotkey listener could already be running with the default push-to-talk configuration. That left first-time users in a confusing state where double-tap was saved in preferences while the live event tap still behaved as press-to-talk until the app restarted.

Add AppState.syncHotKeyConfiguration() as the shared path for applying persisted hotkey settings to the active HotKeyManager. Onboarding now refreshes the live listener when activation mode, hotkey, or double-tap threshold changes, and completeOnboarding() applies the current configuration again before marking setup complete. Settings now uses the same sync path, including max recording duration so the safety timeout remains aligned.

Tests extend the hotkey mock to record configuration updates and cover both direct sync and onboarding completion sync. Local verification: swift test was attempted; the sandboxed run could not write SwiftPM caches, the escalated debug run was blocked by the existing SwiftUI #Preview macro/PreviewsMacros command-line toolchain issue, and the release test run was blocked by local XCTest availability. Manual app testing confirmed the setup wizard hotkey mode issue is fixed.