### PR TITLE
fix: make defualt make command 'make help'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 
 .PHONY: build install install-cli dmg release test clean reset run help
 
+.DEFAULT_GOAL := help
+
 ## Build .app bundle in repo root (fast, for development)
 build:
 	@./scripts/build.sh


### PR DESCRIPTION
Before this PR, running `make` executed the `build` target by default. This PR changes the default target to `help`, so users now see the available Makefile commands and usage information when running `make` without any arguments.
