### PR TITLE
fix: vocamac typing issue in raycast search bar

### DIFF
--- a/Sources/VocaMac/Services/TextInjector.swift
+++ b/Sources/VocaMac/Services/TextInjector.swift
@@ -42,10 +42,20 @@ final class TextInjector {
 
     // MARK: - Public API
 
-    /// Inject text at the current cursor position in any application
+    /// Inject text at the current cursor position in any application.
+    ///
+    /// Strategy (in order):
+    /// 1. **Accessibility API** — sets `kAXSelectedTextAttribute` on the
+    ///    focused element. This inserts text directly without going through
+    ///    any paste handler, which makes it compatible with apps like Raycast
+    ///    whose search bar intercepts Cmd+V before it reaches the text field.
+    /// 2. **Clipboard + Cmd+V** — the legacy approach used as a fallback for
+    ///    apps whose text fields are not writable via the Accessibility API.
+    ///
     /// - Parameters:
     ///   - text: The text to inject
     ///   - preserveClipboard: Whether to save and restore the clipboard contents
+    ///                        (only relevant when the clipboard path is taken)
     func inject(text: String, preserveClipboard: Bool = true) {
         guard !text.isEmpty else { return }
 
@@ -61,6 +71,101 @@ final class TextInjector {
             return
         }
 
+        // Strategy 1: Accessibility API direct insertion.
+        // Works with Raycast, Spotlight, and any app whose focused text field
+        // is writable via the AX API. Preferred because it does not touch the
+        // clipboard and does not require dispatching a keyboard shortcut.
+        if injectViaAccessibility(text: text) {
+            VocaLogger.info(.textInjector, "Text injected via Accessibility API")
+            return
+        }
+
+        // Strategy 2: Clipboard + Cmd+V (legacy fallback).
+        VocaLogger.info(.textInjector, "AX injection unavailable — falling back to clipboard + Cmd+V")
+        injectViaClipboard(text: text, preserveClipboard: preserveClipboard)
+    }
+
+    // MARK: - Strategy 1: Accessibility API
+
+    /// Attempt to insert `text` at the cursor position by writing directly to
+    /// the `kAXSelectedTextAttribute` of the currently focused UI element.
+    ///
+    /// This replaces any active selection with `text`, or inserts at the caret
+    /// when no text is selected — identical to what the user would experience
+    /// when typing.
+    ///
+    /// **Scope:** This strategy is intentionally limited to single-line input
+    /// roles (`AXTextField`, `AXSearchField`, `AXComboBox`). Multi-line
+    /// `AXTextArea` elements — which covers terminal emulators (Terminal.app,
+    /// Ghostty, iTerm2) and code editors — accept the AX attribute write and
+    /// return `.success`, but silently discard or mishandle the text because
+    /// those views process input as a stream of key events, not as a direct
+    /// value mutation. Limiting scope to single-line fields makes AX injection
+    /// reliable for apps like Raycast while letting terminal/editor traffic
+    /// fall through to the clipboard+Cmd+V path that has always worked there.
+    ///
+    /// - Returns: `true` if the text was successfully written via the AX API;
+    ///            `false` if the focused element is unreachable, has an
+    ///            unsupported role, or the write was rejected.
+    @discardableResult
+    private func injectViaAccessibility(text: String) -> Bool {
+        let systemWide = AXUIElementCreateSystemWide()
+        var focusedRef: CFTypeRef?
+
+        let fetchResult = AXUIElementCopyAttributeValue(
+            systemWide,
+            kAXFocusedUIElementAttribute as CFString,
+            &focusedRef
+        )
+        guard fetchResult == .success, let focusedRef else {
+            VocaLogger.debug(.textInjector, "AX: no focused element (\(fetchResult.rawValue))")
+            return false
+        }
+
+        // The returned CFTypeRef must be an AXUIElement.
+        guard CFGetTypeID(focusedRef) == AXUIElementGetTypeID() else {
+            VocaLogger.debug(.textInjector, "AX: focused element is not an AXUIElement")
+            return false
+        }
+
+        // swiftlint:disable force_cast
+        let element = focusedRef as! AXUIElement
+        // swiftlint:enable force_cast
+
+        // Gate on element role. Only single-line input fields reliably handle
+        // a direct kAXSelectedTextAttribute write as "insert text at cursor".
+        // AXTextArea (terminals, editors) must use clipboard+Cmd+V instead.
+        var roleRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef)
+        let role = roleRef as? String ?? ""
+
+        let supportedRoles: Set<String> = ["AXTextField", "AXSearchField", "AXComboBox"]
+        guard supportedRoles.contains(role) else {
+            VocaLogger.debug(.textInjector, "AX: skipping role '\(role)' — not a single-line input field")
+            return false
+        }
+
+        let setResult = AXUIElementSetAttributeValue(
+            element,
+            kAXSelectedTextAttribute as CFString,
+            text as CFTypeRef
+        )
+
+        if setResult == .success {
+            VocaLogger.debug(.textInjector, "AX: inserted \(text.count) chars via kAXSelectedTextAttribute (role: \(role))")
+            return true
+        }
+
+        VocaLogger.debug(.textInjector, "AX: kAXSelectedTextAttribute write failed (\(setResult.rawValue)) — element may be read-only")
+        return false
+    }
+
+    // MARK: - Strategy 2: Clipboard + Cmd+V
+
+    /// Inject text via the system clipboard followed by a simulated Cmd+V.
+    /// This is the original injection strategy and acts as a fallback for
+    /// apps whose focused element is not writable via the Accessibility API.
+    private func injectViaClipboard(text: String, preserveClipboard: Bool) {
         let pasteboard = NSPasteboard.general
 
         // Deep-copy current clipboard state before we overwrite it.

--- a/Tests/VocaMacTests/ServiceTests.swift
+++ b/Tests/VocaMacTests/ServiceTests.swift
@@ -122,6 +122,106 @@ final class TextInjectorTests: XCTestCase {
         // ASCII keyboard layout.
         XCTAssertNil(TextInjector.keyCode(forCharacter: "🎉"))
     }
+
+    // MARK: - Two-Strategy Injection (Raycast compatibility)
+
+    /// The empty-string guard must fire before either strategy (AX API or
+    /// clipboard+Cmd+V) is attempted, so the pasteboard must be unchanged.
+    func testInjectEmptyStringDoesNotModifyClipboard() {
+        let injector = TextInjector()
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString("original content", forType: .string)
+
+        injector.inject(text: "", preserveClipboard: true)
+        injector.inject(text: "", preserveClipboard: false)
+
+        XCTAssertEqual(
+            NSPasteboard.general.string(forType: .string),
+            "original content",
+            "Clipboard must not change when inject() is called with empty text"
+        )
+    }
+
+    /// Verify that inject() with a non-empty string does not crash when the
+    /// Accessibility API strategy declines (no focused single-line input field
+    /// in the test-runner environment). The implementation must fall through
+    /// silently to the clipboard+Cmd+V path.
+    ///
+    /// This also covers the terminal/editor regression fix: AXTextArea elements
+    /// are explicitly excluded from the AX strategy, so terminal emulators
+    /// (Terminal.app, Ghostty) and code editors always use clipboard+Cmd+V.
+    func testInjectNonEmptyStringDoesNotCrashOnAXFallback() {
+        let injector = TextInjector()
+        // No focused AXTextField/AXSearchField/AXComboBox exists in the test
+        // runner, so the AX strategy returns false and the clipboard path runs.
+        // Both preserveClipboard variants must survive without crashing.
+        injector.inject(text: "Hello, Raycast!", preserveClipboard: false)
+        injector.inject(text: "Hello, Raycast!", preserveClipboard: true)
+    }
+
+    /// When the process does not have Accessibility permission,
+    /// inject() must copy the transcribed text to the clipboard (so the
+    /// user can paste manually) and must not crash. This covers the early
+    /// exit at the top of inject() that runs before either strategy.
+    ///
+    /// Skipped on machines where the test runner already has Accessibility
+    /// permission: in that environment the AX strategy path is taken first
+    /// and this specific early-exit code cannot be reached.
+    func testInjectCopiesTextToClipboardWhenNotTrusted() throws {
+        guard !AXIsProcessTrusted() else {
+            throw XCTSkip("Accessibility permission is granted on this machine; the no-permission path cannot be exercised.")
+        }
+
+        let injector = TextInjector()
+        let expected = "raycast fallback dictation"
+
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString("before", forType: .string)
+
+        injector.inject(text: expected, preserveClipboard: false)
+
+        XCTAssertEqual(
+            NSPasteboard.general.string(forType: .string),
+            expected,
+            "When AX permission is absent, inject() must write the text to the clipboard"
+        )
+    }
+
+    /// Verify that when AX permission IS granted but there is no focused
+    /// AX text field (typical in CI / headless test runs), the clipboard
+    /// path is taken and the transcribed text lands on the pasteboard.
+    ///
+    /// This also guards against a regression where the fallback path is
+    /// accidentally short-circuited after the AX strategy returns false.
+    func testClipboardFallbackWritesTextWhenAXStrategyFails() throws {
+        guard AXIsProcessTrusted() else {
+            throw XCTSkip("Accessibility permission is not granted; clipboard fallback cannot be triggered (AX is not even attempted).")
+        }
+
+        let injector = TextInjector()
+        let expected = "fallback text after ax failure"
+
+        // Seed the pasteboard with a known value so we can detect a change.
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString("seed", forType: .string)
+
+        // With no focused text field in the test runner, the AX strategy
+        // will return false, and injectViaClipboard should write expected.
+        injector.inject(text: expected, preserveClipboard: false)
+
+        // Give the async clipboard write a moment to settle.
+        let expectation = XCTestExpectation(description: "clipboard written")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(
+            NSPasteboard.general.string(forType: .string),
+            expected,
+            "When the AX strategy fails, the clipboard fallback must write the text to the pasteboard"
+        )
+    }
 }
 
 // MARK: - SoundManager Tests


### PR DESCRIPTION
fix: #131 

fixed the issue of vocamac typing in raycast search bar, now it works.

## Before

https://github.com/user-attachments/assets/33ec6e72-ad08-4551-85b6-73ebf58bf729

## After

https://github.com/user-attachments/assets/e2fe483f-efd6-4b15-9a16-9519c4607367

## AI and LLM's Assistance

I've used Gemini CLI to assist with this issue, but I personally reviewed all the generated changes before submitting the PR. I also added tests to cover the code introduced in this contribution.

**Model used:** Auto -- Gemini CLI selects the best model for each task automatically, choosing between [gemini-3.1-pro](https://deepmind.google/models/gemini/pro/) and [gemini-3-flash](https://deepmind.google/models/gemini/flash/).


