### PR TITLE
feat: add stats for using vocamac

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -117,6 +117,7 @@ final class AppState: ObservableObject {
     let modelManager: ModelManaging
     let soundManager: SoundPlaying
     let cursorOverlay: CursorOverlayManaging
+    let statsManager: StatsManaging
     let updateChecker = UpdateChecker()
     let permissionManager: any PermissionManaging
 
@@ -147,6 +148,7 @@ final class AppState: ObservableObject {
         modelManager: ModelManaging = ModelManager(),
         soundManager: SoundPlaying = SoundManager(),
         cursorOverlay: CursorOverlayManaging,
+        statsManager: StatsManaging,
         permissionManager: (any PermissionManaging)? = nil,
         skipSystemIntegration: Bool = false
     ) {
@@ -157,6 +159,7 @@ final class AppState: ObservableObject {
         self.modelManager = modelManager
         self.soundManager = soundManager
         self.cursorOverlay = cursorOverlay
+        self.statsManager = statsManager
         self.permissionManager = permissionManager ?? PermissionManager(audioEngine: audioEngine, hotKeyManager: hotKeyManager)
         self.skipSystemIntegration = skipSystemIntegration
 
@@ -172,6 +175,14 @@ final class AppState: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)
+
+        // Forward statsManager changes
+        statsManager.objectWillChangePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
     }
 
     /// Single production AppState instance for the process.
@@ -181,7 +192,10 @@ final class AppState: ObservableObject {
     /// stored-property initialization prevents duplicate service graphs, event
     /// taps, audio observers, and stale SwiftUI environment objects.
     @MainActor
-    private static let sharedProductionInstance = AppState(cursorOverlay: CursorOverlayManager())
+    private static let sharedProductionInstance = AppState(
+        cursorOverlay: CursorOverlayManager(),
+        statsManager: StatsManager()
+    )
 
     /// Convenience factory for creating AppState with all real services.
     /// Needed because CursorOverlayManager is @MainActor and can't be a default parameter.
@@ -513,7 +527,10 @@ final class AppState: ObservableObject {
 
             lastTranscription = result
 
-            // Inject text at cursor position (text is already filtered
+            // Update stats
+            statsManager.recordTranscription(result)
+
+            // Inject text at cursor position
             // by WhisperService to remove hallucination tokens like [BLANK_AUDIO])
             let trimmedText = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmedText.isEmpty {

--- a/Sources/VocaMac/Models/TranscriptionResult.swift
+++ b/Sources/VocaMac/Models/TranscriptionResult.swift
@@ -33,13 +33,14 @@ struct VocaTranscription: Identifiable {
         duration: TimeInterval,
         detectedLanguage: String,
         audioLengthSeconds: Double,
-        modelUsed: ModelSize
+        modelUsed: ModelSize,
+        timestamp: Date = Date()
     ) {
         self.id = UUID()
         self.text = text
         self.duration = duration
         self.detectedLanguage = detectedLanguage
-        self.timestamp = Date()
+        self.timestamp = timestamp
         self.audioLengthSeconds = audioLengthSeconds
         self.modelUsed = modelUsed
     }

--- a/Sources/VocaMac/Models/UserStats.swift
+++ b/Sources/VocaMac/Models/UserStats.swift
@@ -31,7 +31,8 @@ struct UserStats: Codable {
     /// Daily duration to calculate WPM history
     var dailyDurationSeconds: [String: Double] = [:]
 
-    /// Calculated average Words Per Minute (WPM)
+    /// Calculated average Words Per Minute (WPM).
+    /// Note: This is "words-per-minute-of-audio", dividing total words by total audio duration.
     var averageWPM: Double {
         guard totalAudioDurationSeconds > 0 else { return 0 }
         let minutes = totalAudioDurationSeconds / 60.0

--- a/Sources/VocaMac/Models/UserStats.swift
+++ b/Sources/VocaMac/Models/UserStats.swift
@@ -1,0 +1,40 @@
+// UserStats.swift
+// VocaMac
+//
+// Data model for tracking user usage statistics.
+
+import Foundation
+
+struct UserStats: Codable {
+    /// Total number of words transcribed across all sessions
+    var totalWords: Int = 0
+
+    /// Total number of successful transcriptions performed
+    var totalTranscriptions: Int = 0
+
+    /// Total duration of audio recorded in seconds
+    var totalAudioDurationSeconds: Double = 0
+
+    /// Date of the most recent transcription
+    var lastUsageDate: Date?
+
+    /// Current consecutive days of usage
+    var currentStreak: Int = 0
+
+    /// Highest consecutive days of usage recorded
+    var bestStreak: Int = 0
+
+    /// Daily word counts to calculate trends and streaks
+    /// Key is date string in "yyyy-MM-dd" format
+    var dailyWordCounts: [String: Int] = [:]
+
+    /// Daily duration to calculate WPM history
+    var dailyDurationSeconds: [String: Double] = [:]
+
+    /// Calculated average Words Per Minute (WPM)
+    var averageWPM: Double {
+        guard totalAudioDurationSeconds > 0 else { return 0 }
+        let minutes = totalAudioDurationSeconds / 60.0
+        return Double(totalWords) / minutes
+    }
+}

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -138,3 +138,13 @@ extension SpeechTranscribing {
 protocol TextInjecting: AnyObject {
     func inject(text: String, preserveClipboard: Bool)
 }
+
+// MARK: - StatsManaging
+
+@MainActor
+protocol StatsManaging: AnyObject {
+    var stats: UserStats { get }
+    var objectWillChangePublisher: AnyPublisher<Void, Never> { get }
+    func recordTranscription(_ transcription: VocaTranscription)
+    func resetStats()
+}

--- a/Sources/VocaMac/Services/StatsManager.swift
+++ b/Sources/VocaMac/Services/StatsManager.swift
@@ -1,0 +1,126 @@
+// StatsManager.swift
+// VocaMac
+//
+// Manages the persistence and updating of user statistics.
+
+import Foundation
+import Combine
+
+@MainActor
+class StatsManager: StatsManaging, ObservableObject {
+    @Published private(set) var stats: UserStats = UserStats()
+
+    var objectWillChangePublisher: AnyPublisher<Void, Never> {
+        objectWillChange.eraseToAnyPublisher()
+    }
+
+    private let fileManager = FileManager.default
+    private let statsFileName = "stats.json"
+
+    init() {
+        loadStats()
+    }
+
+    private var statsFileURL: URL {
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let vMacDir = appSupport.appendingPathComponent("VocaMac", isDirectory: true)
+
+        // Ensure directory exists
+        if !fileManager.fileExists(atPath: vMacDir.path) {
+            try? fileManager.createDirectory(at: vMacDir, withIntermediateDirectories: true)
+        }
+
+        return vMacDir.appendingPathComponent(statsFileName)
+    }
+
+    private func loadStats() {
+        do {
+            if fileManager.fileExists(atPath: statsFileURL.path) {
+                let data = try Data(contentsOf: statsFileURL)
+                stats = try JSONDecoder().decode(UserStats.self, from: data)
+                VocaLogger.debug(.general, "User stats loaded from disk")
+            } else {
+                VocaLogger.info(.general, "No stats file found, starting fresh")
+            }
+        } catch {
+            VocaLogger.error(.general, "Failed to load stats: \(error.localizedDescription)")
+        }
+    }
+
+    private func saveStats() {
+        do {
+            let data = try JSONEncoder().encode(stats)
+            try data.write(to: statsFileURL, options: .atomic)
+            VocaLogger.debug(.general, "User stats saved to disk")
+        } catch {
+            VocaLogger.error(.general, "Failed to save stats: \(error.localizedDescription)")
+        }
+    }
+
+    func recordTranscription(_ transcription: VocaTranscription) {
+        let text = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+
+        // Estimate word count
+        let words = text.components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .count
+
+        let dateKey = formatDate(transcription.timestamp)
+
+        // Update basic counts
+        stats.totalWords += words
+        stats.totalTranscriptions += 1
+        stats.totalAudioDurationSeconds += transcription.audioLengthSeconds
+
+        // Update daily stats
+        stats.dailyWordCounts[dateKey, default: 0] += words
+        stats.dailyDurationSeconds[dateKey, default: 0] += transcription.audioLengthSeconds
+
+        // Update streaks
+        updateStreaks(currentDate: transcription.timestamp)
+
+        stats.lastUsageDate = transcription.timestamp
+
+        saveStats()
+    }
+
+    func resetStats() {
+        stats = UserStats()
+        saveStats()
+    }
+
+    private func updateStreaks(currentDate: Date) {
+        guard let lastDate = stats.lastUsageDate else {
+            // First time usage
+            stats.currentStreak = 1
+            stats.bestStreak = 1
+            return
+        }
+
+        let calendar = Calendar.current
+
+        // Check if last usage was yesterday
+        if calendar.isDateInYesterday(lastDate) {
+            // Continuation of streak
+            if !calendar.isDate(lastDate, inSameDayAs: currentDate) {
+                stats.currentStreak += 1
+            }
+        } else if calendar.isDate(lastDate, inSameDayAs: currentDate) {
+            // Already used today, streak remains same
+        } else {
+            // Streak broken
+            stats.currentStreak = 1
+        }
+
+        if stats.currentStreak > stats.bestStreak {
+            stats.bestStreak = stats.currentStreak
+        }
+    }
+
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+}

--- a/Sources/VocaMac/Services/StatsManager.swift
+++ b/Sources/VocaMac/Services/StatsManager.swift
@@ -15,22 +15,32 @@ class StatsManager: StatsManaging, ObservableObject {
     }
 
     private let fileManager = FileManager.default
-    private let statsFileName = "stats.json"
+    private let statsFileURL: URL
+    private let calendar: Calendar
 
-    init() {
-        loadStats()
-    }
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
 
-    private var statsFileURL: URL {
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let vMacDir = appSupport.appendingPathComponent("VocaMac", isDirectory: true)
+    init(statsFileURL: URL? = nil, calendar: Calendar = .current) {
+        if let statsFileURL {
+            self.statsFileURL = statsFileURL
+        } else {
+            let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            let vMacDir = appSupport.appendingPathComponent("VocaMac", isDirectory: true)
 
-        // Ensure directory exists
-        if !fileManager.fileExists(atPath: vMacDir.path) {
-            try? fileManager.createDirectory(at: vMacDir, withIntermediateDirectories: true)
+            // Ensure directory exists
+            if !FileManager.default.fileExists(atPath: vMacDir.path) {
+                try? FileManager.default.createDirectory(at: vMacDir, withIntermediateDirectories: true)
+            }
+            self.statsFileURL = vMacDir.appendingPathComponent("stats.json")
         }
-
-        return vMacDir.appendingPathComponent(statsFileName)
+        self.calendar = calendar
+        loadStats()
     }
 
     private func loadStats() {
@@ -66,7 +76,7 @@ class StatsManager: StatsManaging, ObservableObject {
             .filter { !$0.isEmpty }
             .count
 
-        let dateKey = formatDate(transcription.timestamp)
+        let dateKey = Self.dateFormatter.string(from: transcription.timestamp)
 
         // Update basic counts
         stats.totalWords += words
@@ -98,8 +108,6 @@ class StatsManager: StatsManaging, ObservableObject {
             return
         }
 
-        let calendar = Calendar.current
-
         // Check if last usage was yesterday
         if calendar.isDateInYesterday(lastDate) {
             // Continuation of streak
@@ -116,11 +124,5 @@ class StatsManager: StatsManaging, ObservableObject {
         if stats.currentStreak > stats.bestStreak {
             stats.bestStreak = stats.currentStreak
         }
-    }
-
-    private func formatDate(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: date)
     }
 }

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -23,6 +23,11 @@ struct SettingsView: View {
                     Label("Models", systemImage: "brain")
                 }
 
+            StatsSettingsTab()
+                .tabItem {
+                    Label("Stats", systemImage: "chart.xyaxis.line")
+                }
+
             AudioSettingsTab()
                 .tabItem {
                     Label("Audio", systemImage: "waveform")

--- a/Sources/VocaMac/Views/StatsSettingsTab.swift
+++ b/Sources/VocaMac/Views/StatsSettingsTab.swift
@@ -1,0 +1,191 @@
+// StatsSettingsTab.swift
+// VocaMac
+//
+// View for displaying user usage statistics.
+
+import SwiftUI
+
+struct StatsSettingsTab: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                // Key Metrics
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Label("Lifetime Totals", systemImage: "chart.bar.fill")
+                            .font(.headline)
+                            .padding(.bottom, 4)
+
+                        HStack(spacing: 0) {
+                            StatPill(
+                                icon: "text.wordspacing",
+                                label: "Total Words",
+                                value: "\(appState.statsManager.stats.totalWords)",
+                                color: .blue
+                            )
+                            StatPill(
+                                icon: "waveform",
+                                label: "Transcriptions",
+                                value: "\(appState.statsManager.stats.totalTranscriptions)",
+                                color: .purple
+                            )
+                            StatPill(
+                                icon: "timer",
+                                label: "Total Time",
+                                value: formatDuration(appState.statsManager.stats.totalAudioDurationSeconds),
+                                color: .orange
+                            )
+                        }
+                    }
+                    .padding(8)
+                }
+
+                // Performance & Streaks
+                HStack(spacing: 20) {
+                    GroupBox {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Label("Speed", systemImage: "speedometer")
+                                .font(.headline)
+                                .padding(.bottom, 4)
+
+                            Text("\(String(format: "%.1f", appState.statsManager.stats.averageWPM))")
+                                .font(.system(size: 32, weight: .bold, design: .rounded))
+                            + Text(" WPM").font(.headline).foregroundColor(.secondary)
+
+                            Text("Words Per Minute")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(8)
+                    }
+
+                    GroupBox {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Label("Streak", systemImage: "flame.fill")
+                                .font(.headline)
+                                .foregroundStyle(.orange)
+                                .padding(.bottom, 4)
+
+                            Text("\(appState.statsManager.stats.currentStreak)")
+                                .font(.system(size: 32, weight: .bold, design: .rounded))
+                            + Text(" days").font(.headline).foregroundColor(.secondary)
+
+                            Text("Best: \(appState.statsManager.stats.bestStreak) days")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(8)
+                    }
+                }
+
+                // Daily Activity
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Label("Recent Activity", systemImage: "calendar")
+                            .font(.headline)
+                            .padding(.bottom, 4)
+
+                        let days = recentDays()
+                        if days.isEmpty {
+                            Text("No activity recorded yet. Start transcribing to see your progress!")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .padding(.vertical, 20)
+                        } else {
+                            VStack(spacing: 8) {
+                                ForEach(days, id: \.self) { day in
+                                    HStack {
+                                        Text(formatDateString(day))
+                                            .font(.subheadline)
+                                        Spacer()
+                                        Text("\(appState.statsManager.stats.dailyWordCounts[day] ?? 0) words")
+                                            .font(.subheadline)
+                                            .fontWeight(.medium)
+                                    }
+                                    if day != days.last {
+                                        Divider()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .padding(8)
+                }
+
+                Spacer()
+
+                // Reset Button
+                Button(role: .destructive) {
+                    appState.statsManager.resetStats()
+                } label: {
+                    Label("Reset All Statistics", systemImage: "trash")
+                }
+                .controlSize(.small)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.top, 20)
+            }
+            .padding()
+        }
+    }
+
+    private func formatDuration(_ seconds: Double) -> String {
+        if seconds < 60 {
+            return "\(Int(seconds))s"
+        } else if seconds < 3600 {
+            let mins = Int(seconds / 60)
+            let secs = Int(seconds.truncatingRemainder(dividingBy: 60))
+            return "\(mins)m \(secs)s"
+        } else {
+            let hrs = Int(seconds / 3600)
+            let mins = Int((seconds.truncatingRemainder(dividingBy: 3600)) / 60)
+            return "\(hrs)h \(mins)m"
+        }
+    }
+
+    private func recentDays() -> [String] {
+        let keys = Array(appState.statsManager.stats.dailyWordCounts.keys)
+        return keys.sorted(by: >).prefix(7).map { String($0) }
+    }
+
+    private func formatDateString(_ dateString: String) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        guard let date = formatter.date(from: dateString) else { return dateString }
+
+        if Calendar.current.isDateInToday(date) { return "Today" }
+        if Calendar.current.isDateInYesterday(date) { return "Yesterday" }
+
+        formatter.dateFormat = "MMM d, yyyy"
+        return formatter.string(from: date)
+    }
+}
+
+struct StatPill: View {
+    let icon: String
+    let label: String
+    let value: String
+    let color: Color
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(color)
+
+            Text(value)
+                .font(.title3)
+                .fontWeight(.bold)
+
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/Sources/VocaMac/Views/StatsSettingsTab.swift
+++ b/Sources/VocaMac/Views/StatsSettingsTab.swift
@@ -8,6 +8,26 @@ import SwiftUI
 struct StatsSettingsTab: View {
     @EnvironmentObject var appState: AppState
 
+    private static let durationFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute, .second]
+        formatter.unitsStyle = .abbreviated
+        formatter.zeroFormattingBehavior = .dropAll
+        return formatter
+    }()
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    private static let displayDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, yyyy"
+        return formatter
+    }()
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
@@ -117,8 +137,6 @@ struct StatsSettingsTab: View {
                     .padding(8)
                 }
 
-                Spacer()
-
                 // Reset Button
                 Button(role: .destructive) {
                     appState.statsManager.resetStats()
@@ -134,17 +152,7 @@ struct StatsSettingsTab: View {
     }
 
     private func formatDuration(_ seconds: Double) -> String {
-        if seconds < 60 {
-            return "\(Int(seconds))s"
-        } else if seconds < 3600 {
-            let mins = Int(seconds / 60)
-            let secs = Int(seconds.truncatingRemainder(dividingBy: 60))
-            return "\(mins)m \(secs)s"
-        } else {
-            let hrs = Int(seconds / 3600)
-            let mins = Int((seconds.truncatingRemainder(dividingBy: 3600)) / 60)
-            return "\(hrs)h \(mins)m"
-        }
+        return Self.durationFormatter.string(from: seconds) ?? "\(Int(seconds))s"
     }
 
     private func recentDays() -> [String] {
@@ -153,15 +161,12 @@ struct StatsSettingsTab: View {
     }
 
     private func formatDateString(_ dateString: String) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        guard let date = formatter.date(from: dateString) else { return dateString }
+        guard let date = Self.dateFormatter.date(from: dateString) else { return dateString }
 
         if Calendar.current.isDateInToday(date) { return "Today" }
         if Calendar.current.isDateInYesterday(date) { return "Yesterday" }
 
-        formatter.dateFormat = "MMM d, yyyy"
-        return formatter.string(from: date)
+        return Self.displayDateFormatter.string(from: date)
     }
 }
 

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -327,6 +327,34 @@ final class MockTextInjector: TextInjecting {
     }
 }
 
+// MARK: - MockStatsManager
+
+@MainActor
+final class MockStatsManager: StatsManaging, ObservableObject {
+    @Published var stats: UserStats = UserStats()
+
+    var recordCallCount = 0
+    var resetCallCount = 0
+
+    var objectWillChangePublisher: AnyPublisher<Void, Never> {
+        objectWillChange.eraseToAnyPublisher()
+    }
+
+    func recordTranscription(_ transcription: VocaTranscription) {
+        recordCallCount += 1
+        // Simplified word count for testing
+        let words = transcription.text.components(separatedBy: .whitespacesAndNewlines).filter { !$0.isEmpty }.count
+        stats.totalWords += words
+        stats.totalTranscriptions += 1
+        stats.totalAudioDurationSeconds += transcription.audioLengthSeconds
+    }
+
+    func resetStats() {
+        resetCallCount += 1
+        stats = UserStats()
+    }
+}
+
 // MARK: - Test Helper
 
 extension AppState {
@@ -340,6 +368,7 @@ extension AppState {
         let modelManager = MockModelManager()
         let whisperService = MockWhisperService()
         let textInjector = MockTextInjector()
+        let statsManager = MockStatsManager()
 
         let mocks = TestMocks(
             audioEngine: audioEngine,
@@ -349,7 +378,8 @@ extension AppState {
             cursorOverlay: cursorOverlay,
             modelManager: modelManager,
             whisperService: whisperService,
-            textInjector: textInjector
+            textInjector: textInjector,
+            statsManager: statsManager
         )
         let appState = AppState(
             audioEngine: audioEngine,
@@ -359,6 +389,7 @@ extension AppState {
             modelManager: modelManager,
             soundManager: soundManager,
             cursorOverlay: cursorOverlay,
+            statsManager: statsManager,
             permissionManager: permissionManager,
             skipSystemIntegration: true
         )
@@ -375,4 +406,5 @@ struct TestMocks {
     let modelManager: MockModelManager
     let whisperService: MockWhisperService
     let textInjector: MockTextInjector
+    let statsManager: MockStatsManager
 }

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -342,16 +342,10 @@ final class MockStatsManager: StatsManaging, ObservableObject {
 
     func recordTranscription(_ transcription: VocaTranscription) {
         recordCallCount += 1
-        // Simplified word count for testing
-        let words = transcription.text.components(separatedBy: .whitespacesAndNewlines).filter { !$0.isEmpty }.count
-        stats.totalWords += words
-        stats.totalTranscriptions += 1
-        stats.totalAudioDurationSeconds += transcription.audioLengthSeconds
     }
 
     func resetStats() {
         resetCallCount += 1
-        stats = UserStats()
     }
 }
 

--- a/Tests/VocaMacTests/StatsManagerTests.swift
+++ b/Tests/VocaMacTests/StatsManagerTests.swift
@@ -1,0 +1,92 @@
+// StatsManagerTests.swift
+// VocaMac Tests
+//
+// Tests for StatsManager logic including word counting, streaks, and WPM.
+
+import XCTest
+import Combine
+@testable import VocaMac
+
+final class StatsManagerTests: XCTestCase {
+    var statsManager: StatsManager!
+    var cancellables: Set<AnyCancellable>!
+
+    @MainActor
+    override func setUp() {
+        super.setUp()
+        // Use a temporary file for testing persistence if needed, 
+        // but for logic tests we can just use a fresh instance.
+        statsManager = StatsManager()
+        statsManager.resetStats()
+        cancellables = []
+    }
+
+    @MainActor
+    func testInitialStatsAreEmpty() {
+        XCTAssertEqual(statsManager.stats.totalWords, 0)
+        XCTAssertEqual(statsManager.stats.totalTranscriptions, 0)
+        XCTAssertEqual(statsManager.stats.currentStreak, 0)
+    }
+
+    @MainActor
+    func testRecordingTranscriptionUpdatesCounts() {
+        let transcription = VocaTranscription(
+            text: "Hello world this is a test.", // 6 words
+            duration: 1.0,
+            detectedLanguage: "en",
+            audioLengthSeconds: 10.0,
+            modelUsed: .tiny
+        )
+
+        statsManager.recordTranscription(transcription)
+
+        XCTAssertEqual(statsManager.stats.totalWords, 6)
+        XCTAssertEqual(statsManager.stats.totalTranscriptions, 1)
+        XCTAssertEqual(statsManager.stats.totalAudioDurationSeconds, 10.0)
+    }
+
+    @MainActor
+    func testWPMCalculation() {
+        let transcription = VocaTranscription(
+            text: "One two three four five.", // 5 words
+            duration: 1.0,
+            detectedLanguage: "en",
+            audioLengthSeconds: 30.0, // 0.5 minutes
+            modelUsed: .tiny
+        )
+
+        statsManager.recordTranscription(transcription)
+
+        // WPM = 5 words / 0.5 minutes = 10 WPM
+        XCTAssertEqual(statsManager.stats.averageWPM, 10.0)
+    }
+
+    @MainActor
+    func testStreakIncrementsOnNewDay() {
+        let calendar = Calendar.current
+        let today = Date()
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: today)!
+
+        // Record for yesterday
+        let t1 = VocaTranscription(text: "Yesterday", duration: 1.0, detectedLanguage: "en", audioLengthSeconds: 1.0, modelUsed: .tiny)
+        // Manually inject lastUsageDate to yesterday for testing
+        statsManager.recordTranscription(t1)
+        
+        // We need to simulate that the last usage was actually yesterday.
+        // Since recordTranscription sets it to now, we'll manually adjust it for the test.
+        // This requires making some properties internal or using a mockable date provider.
+        // For now, let's just test that it starts at 1.
+        XCTAssertEqual(statsManager.stats.currentStreak, 1)
+    }
+
+    @MainActor
+    func testResetStats() {
+        let transcription = VocaTranscription(text: "Test", duration: 1.0, detectedLanguage: "en", audioLengthSeconds: 1.0, modelUsed: .tiny)
+        statsManager.recordTranscription(transcription)
+        XCTAssertEqual(statsManager.stats.totalTranscriptions, 1)
+
+        statsManager.resetStats()
+        XCTAssertEqual(statsManager.stats.totalTranscriptions, 0)
+        XCTAssertEqual(statsManager.stats.totalWords, 0)
+    }
+}

--- a/Tests/VocaMacTests/StatsManagerTests.swift
+++ b/Tests/VocaMacTests/StatsManagerTests.swift
@@ -10,15 +10,19 @@ import Combine
 final class StatsManagerTests: XCTestCase {
     var statsManager: StatsManager!
     var cancellables: Set<AnyCancellable>!
+    var tempFileURL: URL!
 
     @MainActor
     override func setUp() {
         super.setUp()
-        // Use a temporary file for testing persistence if needed, 
-        // but for logic tests we can just use a fresh instance.
-        statsManager = StatsManager()
-        statsManager.resetStats()
+        tempFileURL = FileManager.default.temporaryDirectory.appendingPathComponent("stats_test_\(UUID().uuidString).json")
+        statsManager = StatsManager(statsFileURL: tempFileURL)
         cancellables = []
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempFileURL)
+        super.tearDown()
     }
 
     @MainActor
@@ -67,16 +71,61 @@ final class StatsManagerTests: XCTestCase {
         let today = Date()
         let yesterday = calendar.date(byAdding: .day, value: -1, to: today)!
 
-        // Record for yesterday
-        let t1 = VocaTranscription(text: "Yesterday", duration: 1.0, detectedLanguage: "en", audioLengthSeconds: 1.0, modelUsed: .tiny)
-        // Manually inject lastUsageDate to yesterday for testing
+        // 1. Record for yesterday
+        let t1 = VocaTranscription(
+            text: "Yesterday transcription",
+            duration: 1.0,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1.0,
+            modelUsed: .tiny,
+            timestamp: yesterday
+        )
         statsManager.recordTranscription(t1)
-        
-        // We need to simulate that the last usage was actually yesterday.
-        // Since recordTranscription sets it to now, we'll manually adjust it for the test.
-        // This requires making some properties internal or using a mockable date provider.
-        // For now, let's just test that it starts at 1.
         XCTAssertEqual(statsManager.stats.currentStreak, 1)
+
+        // 2. Record for today
+        let t2 = VocaTranscription(
+            text: "Today transcription",
+            duration: 1.0,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1.0,
+            modelUsed: .tiny,
+            timestamp: today
+        )
+        statsManager.recordTranscription(t2)
+        XCTAssertEqual(statsManager.stats.currentStreak, 2, "Streak should increment on consecutive days")
+        XCTAssertEqual(statsManager.stats.bestStreak, 2)
+    }
+
+    @MainActor
+    func testStreakBrokenAfterGap() {
+        let calendar = Calendar.current
+        let today = Date()
+        let threeDaysAgo = calendar.date(byAdding: .day, value: -3, to: today)!
+
+        // 1. Record for 3 days ago
+        let t1 = VocaTranscription(
+            text: "Old transcription",
+            duration: 1.0,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1.0,
+            modelUsed: .tiny,
+            timestamp: threeDaysAgo
+        )
+        statsManager.recordTranscription(t1)
+        XCTAssertEqual(statsManager.stats.currentStreak, 1)
+
+        // 2. Record for today (2 day gap)
+        let t2 = VocaTranscription(
+            text: "Today transcription",
+            duration: 1.0,
+            detectedLanguage: "en",
+            audioLengthSeconds: 1.0,
+            modelUsed: .tiny,
+            timestamp: today
+        )
+        statsManager.recordTranscription(t2)
+        XCTAssertEqual(statsManager.stats.currentStreak, 1, "Streak should reset after a gap")
     }
 
     @MainActor


### PR DESCRIPTION
Now users can see the stats of how much words they transcribe using Vocamac, what's the words per minute, speed and what's the streak of them using Vocamac.

<img width="559" height="568" alt="Screenshot 2026-06-01 at 3 44 34 PM" src="https://github.com/user-attachments/assets/788a515e-3f1e-4686-8170-a09656a65d2e" />

## AI and LLM's Assistance

I've used Gemini CLI to assist with this issue, but I personally reviewed all the generated changes before submitting the PR. I also added tests to cover the code introduced in this contribution.

**Model used:** Auto -- Gemini CLI selects the best model for each task automatically, choosing between [gemini-3.1-pro](https://deepmind.google/models/gemini/pro/) and [gemini-3-flash](https://deepmind.google/models/gemini/flash/).
