### PR TITLE
fix: show onboarding quick test result

### DIFF
--- a/Sources/VocaMac/Views/OnboardingView.swift
+++ b/Sources/VocaMac/Views/OnboardingView.swift
@@ -792,11 +792,13 @@ struct QuickTestStep: View {
             Task { @MainActor in
                 await appState.stopRecordingAndTranscribe()
                 isRecording = false
+                testResult = appState.lastTranscription?.text
             }
         } else {
             Task { @MainActor in
+                testResult = nil
                 await appState.startRecording()
-                isRecording = true
+                isRecording = appState.appStatus == .recording || appState.isRecording
             }
         }
     }


### PR DESCRIPTION
## Summary
- Populate the existing onboarding Quick Test result box after recording stops
- Clear stale quick-test output before starting a new recording
- Keep the local recording indicator aligned with whether recording actually started

## Testing
- swift build -c release
- Manually verified the onboarding Quick Test flow locally

### Before

https://github.com/user-attachments/assets/7240f8b5-7342-492e-b231-7a796bcf9d9c


### After
<img width="595" height="577" alt="image" src="https://github.com/user-attachments/assets/9d1f600f-e8e1-4d9c-9728-717edd630ac1" />

