### PR TITLE
Add UI to delete downloaded models

### DIFF
--- a/Sources/VocaMac/Models/AppState.swift
+++ b/Sources/VocaMac/Models/AppState.swift
@@ -984,6 +984,32 @@ final class AppState: ObservableObject {
         }
     }
 
+    /// Delete a downloaded model's local files, freeing disk space.
+    /// Refuses to delete the currently active model — the user must load a
+    /// different model first so the app is never left without a loaded model —
+    /// and refuses a model that's mid-download or mid-load, so its files
+    /// aren't yanked out from under an in-flight read.
+    func deleteModel(_ size: ModelSize) async {
+        guard let index = availableModels.firstIndex(where: { $0.size == size }) else { return }
+        guard !availableModels[index].isActive else {
+            errorMessage = "Can't delete the active model. Load a different model first."
+            return
+        }
+        guard !availableModels[index].isLoading, availableModels[index].downloadProgress == nil else {
+            errorMessage = "Can't delete a model that's loading or downloading."
+            return
+        }
+
+        do {
+            try await modelManager.deleteModel(size)
+            refreshModelStatuses()
+            VocaLogger.info(.appState, "Deleted model \(size.displayName)")
+        } catch {
+            errorMessage = "Delete failed: \(error.localizedDescription)"
+            VocaLogger.error(.appState, "Delete failed for \(size.displayName): \(error.localizedDescription)")
+        }
+    }
+
     /// Refresh the download status of all models
     /// This ensures that all previously downloaded models are detected and marked correctly
     private func refreshModelStatuses() {

--- a/Sources/VocaMac/Services/ModelManager.swift
+++ b/Sources/VocaMac/Services/ModelManager.swift
@@ -730,20 +730,28 @@ final class ModelManager {
 
     // MARK: - Model Deletion
 
-    /// Delete a downloaded model's local files
-    func deleteModel(_ size: ModelSize) throws {
+    /// Delete a downloaded model's local files.
+    ///
+    /// `async` so callers on `@MainActor` (the Settings UI) don't block while
+    /// removing a multi-gigabyte model directory — `ModelManager` carries no
+    /// actor isolation of its own, so the removal runs off the main thread.
+    func deleteModel(_ size: ModelSize) async throws {
         let modelDir: URL
         switch size.engine {
         case .whisperKit:
             modelDir = modelStorageBase.appendingPathComponent(whisperKitModelName(for: size))
         case .parakeet:
-            guard let version = parakeetVersion(for: size) else { return }
+            guard let version = parakeetVersion(for: size) else {
+                throw ModelManagerError.modelNotAvailable(modelIdentifier(for: size))
+            }
             modelDir = parakeetDirectory(for: version)
         case .appleSpeech:
             // System-managed assets cannot be deleted by the app.
             return
         case .sherpaOnnx:
-            guard let spec = SherpaModelCatalog.spec(for: size) else { return }
+            guard let spec = SherpaModelCatalog.spec(for: size) else {
+                throw ModelManagerError.modelNotAvailable(modelIdentifier(for: size))
+            }
             modelDir = SherpaService.modelDirectory(for: spec)
         }
 

--- a/Sources/VocaMac/Services/ServiceProtocols.swift
+++ b/Sources/VocaMac/Services/ServiceProtocols.swift
@@ -104,6 +104,7 @@ protocol ModelManaging: AnyObject {
     func modelIdentifier(for size: ModelSize) -> String
     func modelSize(from identifier: String) -> ModelSize?
     func downloadModel(size: ModelSize, onProgress: @escaping (Double) -> Void) async throws
+    func deleteModel(_ size: ModelSize) async throws
     func diskUsageDescription() -> String
 }
 

--- a/Sources/VocaMac/Views/SettingsView.swift
+++ b/Sources/VocaMac/Views/SettingsView.swift
@@ -491,6 +491,15 @@ struct ModelRow: View {
     let model: WhisperModelInfo
     @ObservedObject var appState: AppState
     @State private var showForceDownloadAlert = false
+    @State private var showDeleteAlert = false
+
+    /// Apple Speech models are managed by the OS, not stored by the app, so there's nothing to
+    /// delete. A model that's mid-load or mid-download is also excluded so its files aren't
+    /// removed out from under an in-flight read.
+    private var canDelete: Bool {
+        model.isDownloaded && !model.isActive && !model.size.isSystemManaged
+            && !model.isLoading && model.downloadProgress == nil
+    }
 
     var body: some View {
         HStack {
@@ -608,6 +617,18 @@ struct ModelRow: View {
                 }
                 .controlSize(.small)
             }
+
+            if canDelete {
+                Button {
+                    showDeleteAlert = true
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .controlSize(.small)
+                .buttonStyle(.borderless)
+                .foregroundStyle(.secondary)
+                .help("Delete downloaded model")
+            }
         }
         .padding(.vertical, 8)
         .padding(.horizontal, 4)
@@ -625,6 +646,14 @@ struct ModelRow: View {
             }
         } message: {
             Text("WhisperKit hasn't verified this model on your chip family. It may fail to load, or it may run slower than tuned models.")
+        }
+        .alert("Delete \(model.size.displayName)?", isPresented: $showDeleteAlert) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) {
+                Task { @MainActor in await appState.deleteModel(model.size) }
+            }
+        } message: {
+            Text("This removes the downloaded model file (\(model.size.fileSizeDescription)) from disk. You can download it again later.")
         }
     }
 }

--- a/Tests/VocaMacTests/AppStateTests.swift
+++ b/Tests/VocaMacTests/AppStateTests.swift
@@ -347,6 +347,66 @@ final class AppStateModelLoadingTests: XCTestCase {
     }
 
     @MainActor
+    func testDeleteModelRemovesDownloadedModel() async {
+        let modelManager = MockModelManager()
+        modelManager.downloadedModels = [.small, .medium]
+        let (appState, _) = AppState.makeTestState(modelManager: modelManager)
+
+        await appState.deleteModel(.medium)
+
+        XCTAssertEqual(modelManager.deletedModels, [.medium])
+        XCTAssertEqual(appState.availableModels.first(where: { $0.size == .medium })?.isDownloaded, false)
+        XCTAssertNil(appState.errorMessage)
+    }
+
+    @MainActor
+    func testDeleteModelRefusesToDeleteTheActiveModel() async {
+        let modelManager = MockModelManager()
+        modelManager.downloadedModels = [.small]
+        let (appState, _) = AppState.makeTestState(modelManager: modelManager)
+
+        await appState.loadModel(.small)
+        await appState.deleteModel(.small)
+
+        XCTAssertTrue(modelManager.deletedModels.isEmpty)
+        XCTAssertEqual(appState.availableModels.first(where: { $0.size == .small })?.isDownloaded, true)
+        XCTAssertTrue(appState.errorMessage?.contains("active model") == true)
+    }
+
+    @MainActor
+    func testDeleteModelRefusesToDeleteAModelThatIsLoading() async {
+        // A model mid-load or mid-download must not have its files pulled out
+        // from under the in-flight read.
+        let modelManager = MockModelManager()
+        modelManager.downloadedModels = [.small]
+        let (appState, _) = AppState.makeTestState(modelManager: modelManager)
+        let index = appState.availableModels.firstIndex(where: { $0.size == .small })!
+        appState.availableModels[index].isLoading = true
+
+        await appState.deleteModel(.small)
+
+        XCTAssertTrue(modelManager.deletedModels.isEmpty)
+        XCTAssertTrue(appState.errorMessage?.contains("loading") == true)
+    }
+
+    @MainActor
+    func testDeleteModelSurfacesUnderlyingError() async {
+        let modelManager = MockModelManager()
+        modelManager.downloadedModels = [.small]
+        modelManager.deleteModelError = NSError(
+            domain: "VocaMacTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Permission denied"]
+        )
+        let (appState, _) = AppState.makeTestState(modelManager: modelManager)
+
+        await appState.deleteModel(.small)
+
+        XCTAssertTrue(appState.errorMessage?.contains("Permission denied") == true)
+        XCTAssertEqual(appState.availableModels.first(where: { $0.size == .small })?.isDownloaded, true)
+    }
+
+    @MainActor
     func testStartupFallsBackFromUnsupportedMediumPreference() async {
         UserDefaults.standard.set(ModelSize.medium.rawValue, forKey: "vocamac.selectedModelSize")
 

--- a/Tests/VocaMacTests/Mocks/MockServices.swift
+++ b/Tests/VocaMacTests/Mocks/MockServices.swift
@@ -335,6 +335,17 @@ final class MockModelManager: ModelManaging {
         downloadedModels.insert(size)
     }
 
+    var deleteModelError: Error?
+    var deletedModels: [ModelSize] = []
+
+    func deleteModel(_ size: ModelSize) async throws {
+        if let deleteModelError {
+            throw deleteModelError
+        }
+        downloadedModels.remove(size)
+        deletedModels.append(size)
+    }
+
     func diskUsageDescription() -> String {
         diskUsage
     }


### PR DESCRIPTION
## Demo


https://github.com/user-attachments/assets/15ba9bb8-5620-481e-a4e6-ea95099144d0



## Summary
- Settings > Models could download and load models but had no way to remove one, even though `ModelManager` already had an unused `deleteModel` implementation.
- Adds a trash button on downloaded, inactive models in `ModelRow`, behind a confirmation alert. Hidden for the active model, a model that's mid-load/download, and OS-managed Apple Speech (nothing on disk to delete).
- `ModelManager.deleteModel` is now `async` so removing a large model doesn't block the Settings UI on the main thread, and it throws instead of silently no-op'ing when a Parakeet/sherpa-onnx catalog lookup misses.
- `AppState.deleteModel` refuses to delete the active model or a model that's currently loading/downloading, surfacing a clear error instead.

## Test plan
- [x] `swift build` succeeds
- [x] `swift test` — all 285 tests pass, including new coverage: successful delete, refusing to delete the active model, refusing to delete a loading model, and surfacing an underlying delete error
- [X] Manually verify in the app: download a model, delete it via the trash button, confirm the alert and resulting state